### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "video",
     "player"
   ],
+  "repository" : {
+    "type" : "git",
+    "url" : "http://github.com/brightcove/videojs-overlay.git"
+  },
   "dependencies": {},
   "devDependencies": {
     "grunt-contrib-clean": "^0.4",


### PR DESCRIPTION
Provide link to Github project from NPMjs.org registry.

Currently, it's very difficult to find this repo from the npmjs.org listing. The NPM listing should have a link to this repo. It's impossible to find the example file otherwise. Thanks!
