### PR TITLE
feat: make overlays mutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ There's also a [working example](https://github.com/brightcove/videojs-overlay/b
 #### `player.overlay()`
 This is the main interface and the way to initialize this plugin. It takes [an options object as input](#plugin-options).
 
-#### `overlay.getOverlays()`
+#### `overlay.get()`
 
 Returns an array of all the overlays set up for the current video.
 
@@ -79,8 +79,7 @@ var addedOverlays = overlay.add({content: "this is a new one", start: "play", en
 
 #### `overlay.remove(Object)`
 
-Removes an individual overlay from the list of overlays. Calling this method with an invalid overlay object
-throws an error.
+Removes an individual overlay from the list of overlays. Calling this method with an invalid overlay object removes nothing from the list.
 
 ```js
 var overlay = player.overlay({
@@ -92,7 +91,7 @@ var overlay = player.overlay({
     end: 'pause'
   }]
 });
-const overlayToRemove = overlay.getOverlays()[0];
+const overlayToRemove = overlay.get()[0];
 overlay.remove(overlayToRemove);
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,53 @@ There's also a [working example](https://github.com/brightcove/videojs-overlay/b
 
 ## Documentation
 
+### API
+#### `player.overlay()`
+This is the main interface and the way to initialize this plugin. It takes [an options object as input](#plugin-options).
+
+#### `overlay.overlays`
+
+An array of all the overlays set up for the current video.
+
+#### `overlay.add(Object|Array)`
+
+Adds one or more overlays to the current list of overlays without replacing the current list of overlays.
+Returns a reference to the added overlays.
+
+```js
+var overlay = player.overlay({
+  content: 'Default overlay content',
+  debug: true,
+  overlays: [{
+    content: 'The video is playing!',
+    start: 'play',
+    end: 'pause'
+  }]
+});
+var addedOverlays = overlay.add({content: "this is a new one", start: "play", end: "pause"});
+```
+
+
+#### `overlay.remove(Object)`
+
+Removes an individual overlay from the list of overlays. Calling this method with an invalid overlay object
+throws an error.
+
+```js
+var overlay = player.overlay({
+  content: 'Default overlay content',
+  debug: true,
+  overlays: [{
+    content: 'The video is playing!',
+    start: 'play',
+    end: 'pause'
+  }]
+});
+const overlayToRemove = overlay.overlays[0];
+overlay.remove(overlayToRemove);
+```
+
+
 ### Plugin Options
 
 You may pass in an options object to the plugin upon initialization. This

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Maintenance Status: Stable
 
 - [Getting Started](#getting-started)
 - [Documentation](#documentation)
+  - [API](#api)
+    - [`player.overlay()`](#playeroverlay)
+    - [`overlay.overlays`](#overlayoverlays)
+    - [`overlay.add(object|array)`](#overlayaddobjectarray)
+    - [`overlay.remove(object)`](#overlayremoveobject)
   - [Plugin Options](#plugin-options)
     - [`align`](#align)
     - [`showBackground`](#showbackground)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Maintenance Status: Stable
 - [Documentation](#documentation)
   - [API](#api)
     - [`player.overlay()`](#playeroverlay)
-    - [`overlay.overlays`](#overlayoverlays)
+    - [`overlay.get()`](#overlayget)
     - [`overlay.add(object|array)`](#overlayaddobjectarray)
     - [`overlay.remove(object)`](#overlayremoveobject)
   - [Plugin Options](#plugin-options)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Adds one or more overlays to the current list of overlays without replacing the 
 Returns a reference to the added overlays.
 
 ```js
-var overlay = player.overlay({
+const overlay = player.overlay({
   content: 'Default overlay content',
   debug: true,
   overlays: [{
@@ -73,7 +73,7 @@ var overlay = player.overlay({
     end: 'pause'
   }]
 });
-var addedOverlays = overlay.add({content: "this is a new one", start: "play", end: "pause"});
+const addedOverlays = overlay.add({content: "this is a new one", start: "play", end: "pause"});
 ```
 
 
@@ -82,7 +82,7 @@ var addedOverlays = overlay.add({content: "this is a new one", start: "play", en
 Removes an individual overlay from the list of overlays. Calling this method with an invalid overlay object removes nothing from the list.
 
 ```js
-var overlay = player.overlay({
+const overlay = player.overlay({
   content: 'Default overlay content',
   debug: true,
   overlays: [{

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ There's also a [working example](https://github.com/brightcove/videojs-overlay/b
 #### `player.overlay()`
 This is the main interface and the way to initialize this plugin. It takes [an options object as input](#plugin-options).
 
-#### `overlay.overlays`
+#### `overlay.getOverlays()`
 
-An array of all the overlays set up for the current video.
+Returns an array of all the overlays set up for the current video.
 
 #### `overlay.add(Object|Array)`
 
@@ -92,7 +92,7 @@ var overlay = player.overlay({
     end: 'pause'
   }]
 });
-const overlayToRemove = overlay.overlays[0];
+const overlayToRemove = overlay.getOverlays()[0];
 overlay.remove(overlayToRemove);
 ```
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,8 @@
         overlays: [{
           content: 'The video is playing!',
           start: 'play',
-          end: 'pause'
+          end: 'pause',
+          align: 'bottom-right'
         }, {
           start: 0,
           end: 15,

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         }]
       });
       const added = overlay.add({content: "this is a new one", start: "play", end: "pause"});
-      overlay.remove(added);
+      overlay.remove(added[0]);
     }(window, window.videojs));
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
   <script src="dist/videojs-overlay.js"></script>
   <script>
     (function(window, videojs) {
-      var player = window.player = videojs('videojs-overlay-player');
-      var overlay = player.overlay({
+      const player = window.player = videojs('videojs-overlay-player');
+      const overlay = player.overlay({
         content: 'Default overlay content',
         debug: true,
         overlays: [{

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         }]
       });
       overlay.add({content: "this is a new one", start: "play", end: "pause"});
-      overlay.remove()
+      overlay.remove();
     }(window, window.videojs));
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <script>
     (function(window, videojs) {
       var player = window.player = videojs('videojs-overlay-player');
-      player.overlay({
+      var overlay = player.overlay({
         content: 'Default overlay content',
         debug: true,
         overlays: [{
@@ -43,6 +43,8 @@
           end: 'pause'
         }]
       });
+      overlay.add({content: "this is a new one", start: "play", end: "pause"});
+      overlay.remove()
     }(window, window.videojs));
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -43,8 +43,7 @@
           end: 'pause'
         }]
       });
-      const added = overlay.add({content: "this is a new one", start: "play", end: "pause"});
-      overlay.remove(added[0]);
+      overlay.add({content: "this is a new one", start: "play", end: "pause"});
     }(window, window.videojs));
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -43,8 +43,8 @@
           end: 'pause'
         }]
       });
-      overlay.add({content: "this is a new one", start: "play", end: "pause"});
-      overlay.remove();
+      const added = overlay.add({content: "this is a new one", start: "play", end: "pause"});
+      overlay.remove(added);
     }(window, window.videojs));
   </script>
 </body>

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
       "git add"
     ],
     "README.md": [
-      "npm run docs:toc",
       "git add"
     ]
   },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -358,13 +358,13 @@ const plugin = function(options) {
     });
   };
 
-  // convert this into a sep function that can be recalled?
   this.overlays_ = mapOverlays(overlays);
 
   /**
    * Adding a single or a list of overlays.
    *
    * @param {*} items
+   * @return {*} added overlays or smth like that
    */
   function add(items) {
     if (!Array.isArray(items)) {
@@ -374,19 +374,32 @@ const plugin = function(options) {
     const addedOverlays = mapOverlays(items);
 
     self.overlays_ = self.overlays_.concat(addedOverlays);
+
+    // return addedOverlays
+    return addedOverlays;
   }
 
   /**
-   *  Removing an overlay? not sure how it should work?? by index?
+   *  Given a reference to an overlay object, remove that corresponding object from
+   * this.overlays_
+   *
+   * @param {*} item
    */
-  function remove() {
+  function remove(item) {
+    const index = self.overlays_.indexOf(item);
 
+    if (index !== -1) {
+      item.el().parentNode.removeChild(item.el());
+      self.overlays_.splice(index, 1);
+    } else {
+      throw new Error('overlay object is invalid and cannot be removed');
+    }
   }
 
   return {
     add,
     remove,
-    length: this.overlays_.length
+    overlays: this.overlays_
   };
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -367,15 +367,17 @@ const plugin = function(options) {
    * @param {*} items
    */
   function add(items) {
-    items = [items];
-    self.overlays_ = self.overlays_.concat(mapOverlays(items));
-    // convert item/s to an array
-    // add the items to the list of existing overlays (this.overlays_)
-    // can you attachToControlBar individual overlays? doesn't seem like it based off of the tests in the plugin
+    if (!Array.isArray(items)) {
+      items = [items];
+    }
+
+    const addedOverlays = mapOverlays(items);
+
+    self.overlays_ = self.overlays_.concat(addedOverlays);
   }
 
   /**
-   *
+   *  Removing an overlay? not sure how it should work?? by index?
    */
   function remove() {
 
@@ -383,7 +385,8 @@ const plugin = function(options) {
 
   return {
     add,
-    remove
+    remove,
+    length: this.overlays_.length
   };
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -302,7 +302,7 @@ videojs.registerComponent('Overlay', Overlay);
  * @param    {Object} [options={}]
  */
 const plugin = function(options) {
-  const self = this;
+  const player = this;
   const settings = videojs.mergeOptions(defaults, options);
 
   // De-initialize the plugin if it already has an array of overlays.
@@ -375,7 +375,7 @@ const plugin = function(options) {
 
     const addedOverlays = mapOverlays(item);
 
-    self.overlays_ = self.overlays_.concat(addedOverlays);
+    player.overlays_ = player.overlays_.concat(addedOverlays);
 
     return addedOverlays;
   }
@@ -390,13 +390,13 @@ const plugin = function(options) {
    *
    */
   function remove(item) {
-    const index = self.overlays_.indexOf(item);
+    const index = player.overlays_.indexOf(item);
 
     if (index !== -1) {
       item.el().parentNode.removeChild(item.el());
-      self.overlays_.splice(index, 1);
+      player.overlays_.splice(index, 1);
     } else {
-      throw new Error('overlay is invalid and cannot be removed');
+      player.log.warn('overlay does not exist and cannot be removed');
     }
   }
 
@@ -405,14 +405,14 @@ const plugin = function(options) {
    *
    * @return The array of overlay objects currently used by the plugin
    */
-  function getOverlays() {
-    return self.overlays_;
+  function get() {
+    return player.overlays_;
   }
 
   return {
     add,
     remove,
-    getOverlays
+    get
   };
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -302,7 +302,6 @@ videojs.registerComponent('Overlay', Overlay);
  * @param    {Object} [options={}]
  */
 const plugin = function(options) {
-  // TODO is this the best way to be able to use this inside the add/remove fns?
   const self = this;
   const settings = videojs.mergeOptions(defaults, options);
 
@@ -359,31 +358,35 @@ const plugin = function(options) {
   };
 
   this.overlays_ = mapOverlays(overlays);
-
   /**
-   * Adding a single or a list of overlays.
+   * Adds one or more items to the existing list of overlays.
    *
-   * @param {*} items
-   * @return {*} added overlays or smth like that
+   * @param {Object|Array} item
+   *        An item (or an array of items) to be added as overlay/s
+   *
+   * @return {Array[Overlay]}
+   *         The array of overlay objects that were added
    */
-  function add(items) {
-    if (!Array.isArray(items)) {
-      items = [items];
+  function add(item) {
+    if (!Array.isArray(item)) {
+      item = [item];
     }
 
-    const addedOverlays = mapOverlays(items);
+    const addedOverlays = mapOverlays(item);
 
     self.overlays_ = self.overlays_.concat(addedOverlays);
 
-    // return addedOverlays
     return addedOverlays;
   }
 
   /**
-   *  Given a reference to an overlay object, remove that corresponding object from
-   * this.overlays_
    *
-   * @param {*} item
+   * @param {Overlay} item
+   *        An item to be removed from the array of overlays
+   *
+   * @throws {Error}
+   *        Item to remove must be present in the array of overlays
+   *
    */
   function remove(item) {
     const index = self.overlays_.indexOf(item);
@@ -392,7 +395,7 @@ const plugin = function(options) {
       item.el().parentNode.removeChild(item.el());
       self.overlays_.splice(index, 1);
     } else {
-      throw new Error('overlay object is invalid and cannot be removed');
+      throw new Error('overlay is invalid and cannot be removed');
     }
   }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -358,6 +358,7 @@ const plugin = function(options) {
   };
 
   this.overlays_ = mapOverlays(overlays);
+
   /**
    * Adds one or more items to the existing list of overlays.
    *
@@ -399,10 +400,19 @@ const plugin = function(options) {
     }
   }
 
+  /**
+   * Gets the array of overlays used for the current video
+   *
+   * @return The array of overlay objects currently used by the plugin
+   */
+  function getOverlays() {
+    return self.overlays_;
+  }
+
   return {
     add,
     remove,
-    overlays: this.overlays_
+    getOverlays
   };
 };
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -808,6 +808,25 @@ QUnit.test('attach overlays as last child when no controls are present', functio
   );
 });
 
+QUnit.test('can get all existing overlays with the `getOverlay` fn', function(assert) {
+  assert.expect(1);
+  this.player.controls(false);
+
+  const overlay = this.player.overlay({
+    overlays: [{
+      content: 'this is the first overlay',
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  const overlays = overlay.getOverlays();
+
+  assert.equal(overlays[0].options_.content, 'this is the first overlay');
+});
+
 QUnit.test('can add an individual overlay using the `add` fn', function(assert) {
   assert.expect(3);
   this.player.controls(false);
@@ -882,7 +901,7 @@ QUnit.test('can remove an overlay using the `remove` fn', function(assert) {
     'bottom gets added as second last child of player'
   );
 
-  overlay.remove(overlay.overlays[0]);
+  overlay.remove(overlay.getOverlays()[0]);
 
   assert.notOk(
     this.player.$('.vjs-overlay.vjs-overlay-bottom'),

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -807,3 +807,11 @@ QUnit.test('attach overlays as last child when no controls are present', functio
     'top attaches as last child of player'
   );
 });
+
+QUnit.test('can add individual overlay using the `add` fn', function(assert) {
+
+});
+
+QUnit.test('can remove an overlay', function(assert) {
+
+});

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -808,7 +808,7 @@ QUnit.test('attach overlays as last child when no controls are present', functio
   );
 });
 
-QUnit.test('can get all existing overlays with the `getOverlay` fn', function(assert) {
+QUnit.test('can get all existing overlays with the `get` fn', function(assert) {
   assert.expect(1);
   this.player.controls(false);
 
@@ -822,7 +822,7 @@ QUnit.test('can get all existing overlays with the `getOverlay` fn', function(as
 
   this.player.trigger('start');
 
-  const overlays = overlay.getOverlays();
+  const overlays = overlay.get();
 
   assert.equal(overlays[0].options_.content, 'this is the first overlay');
 });
@@ -901,7 +901,7 @@ QUnit.test('can remove an overlay using the `remove` fn', function(assert) {
     'bottom gets added as second last child of player'
   );
 
-  overlay.remove(overlay.getOverlays()[0]);
+  overlay.remove(overlay.get()[0]);
 
   assert.notOk(
     this.player.$('.vjs-overlay.vjs-overlay-bottom'),
@@ -909,7 +909,7 @@ QUnit.test('can remove an overlay using the `remove` fn', function(assert) {
   );
 });
 
-QUnit.test('`remove` fn throws an error if an invalid overlay is passed into it', function(assert) {
+QUnit.test('`remove` fn does not remove anything if an invalid overlay is passed into it', function(assert) {
   assert.expect(2);
   this.player.controls(false);
 
@@ -926,7 +926,11 @@ QUnit.test('`remove` fn throws an error if an invalid overlay is passed into it'
     'bottom gets added as last child of player'
   );
 
-  assert.throws(() => {
-    overlay.remove(undefined);
-  }, Error, 'error is thrown with an invalid overlay');
+  overlay.remove(undefined);
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.el().lastChild,
+    'bottom is still last child of player'
+  );
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -808,10 +808,77 @@ QUnit.test('attach overlays as last child when no controls are present', functio
   );
 });
 
-QUnit.test('can add individual overlay using the `add` fn', function(assert) {
+QUnit.test('can add an individual overlay using the `add` fn', function(assert) {
+  assert.expect(2);
+  this.player.controls(false);
 
+  const overlay = this.player.overlay({
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.el().lastChild,
+    'initial bottom overlay is attached as last child of player'
+  );
+
+  overlay.add({start: 'start', align: 'top'});
+
+  this.player.trigger('start');
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-top'),
+    this.player.el().lastChild,
+    'top gets added as last child of player'
+  );
+  // need to write the following test -> one overlay, then add one and verify it exists, then add another and check if exists.
+});
+
+QUnit.test('can add a list of overlays using the `add` fn', function(assert) {
+  assert.expect(2);
+  this.player.controls(false);
+
+  const overlay = this.player.overlay();
+
+  overlay.add([{start: 'start', align: 'top'}, {start: 'start', align: 'bottom'}]);
+
+  this.player.trigger('start');
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.el().lastChild,
+    'bottom gets added as last child of player'
+  );
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-top'),
+    this.player.el().lastChild.previousSibling,
+    'top gets added as second last child of player'
+  );
 });
 
 QUnit.test('can remove an overlay', function(assert) {
+  assert.expect(2);
+  this.player.controls(false);
 
+  const overlay = this.player.overlay({
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }]
+  });
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.el().lastChild,
+    'bottom gets added as last child of player'
+  );
+
+  overlay.remove();
+
+  assert.ok(1 === 2);
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -809,7 +809,7 @@ QUnit.test('attach overlays as last child when no controls are present', functio
 });
 
 QUnit.test('can add an individual overlay using the `add` fn', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
   this.player.controls(false);
 
   const overlay = this.player.overlay({
@@ -827,7 +827,9 @@ QUnit.test('can add an individual overlay using the `add` fn', function(assert) 
     'initial bottom overlay is attached as last child of player'
   );
 
-  overlay.add({start: 'start', align: 'top'});
+  const addedOverlay = overlay.add({content: 'newly added overlay', start: 'start', align: 'top'});
+
+  assert.equal(addedOverlay[0].options_.content, 'newly added overlay', 'added overlay object is returned by `add` fn');
 
   this.player.trigger('start');
   assert.equal(
@@ -843,7 +845,6 @@ QUnit.test('can add a list of overlays using the `add` fn', function(assert) {
 
   const overlay = this.player.overlay();
 
-  // test added overlays lenght and objects inside
   overlay.add([{start: 'start', align: 'top'}, {start: 'start', align: 'bottom'}]);
 
   this.player.trigger('start');

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -835,7 +835,6 @@ QUnit.test('can add an individual overlay using the `add` fn', function(assert) 
     this.player.el().lastChild,
     'top gets added as last child of player'
   );
-  // need to write the following test -> one overlay, then add one and verify it exists, then add another and check if exists.
 });
 
 QUnit.test('can add a list of overlays using the `add` fn', function(assert) {
@@ -844,6 +843,7 @@ QUnit.test('can add a list of overlays using the `add` fn', function(assert) {
 
   const overlay = this.player.overlay();
 
+  // test added overlays lenght and objects inside
   overlay.add([{start: 'start', align: 'top'}, {start: 'start', align: 'bottom'}]);
 
   this.player.trigger('start');
@@ -861,7 +861,35 @@ QUnit.test('can add a list of overlays using the `add` fn', function(assert) {
   );
 });
 
-QUnit.test('can remove an overlay', function(assert) {
+QUnit.test('can remove an overlay using the `remove` fn', function(assert) {
+  assert.expect(2);
+  this.player.controls(false);
+
+  const overlay = this.player.overlay({
+    overlays: [{
+      start: 'start',
+      align: 'bottom'
+    }, {
+      start: 'start',
+      align: 'top'
+    }]
+  });
+
+  assert.equal(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    this.player.el().lastChild.previousSibling,
+    'bottom gets added as second last child of player'
+  );
+
+  overlay.remove(overlay.overlays[0]);
+
+  assert.notOk(
+    this.player.$('.vjs-overlay.vjs-overlay-bottom'),
+    'bottom overlay has been removed'
+  );
+});
+
+QUnit.test('`remove` fn throws an error if an invalid overlay is passed into it', function(assert) {
   assert.expect(2);
   this.player.controls(false);
 
@@ -878,7 +906,7 @@ QUnit.test('can remove an overlay', function(assert) {
     'bottom gets added as last child of player'
   );
 
-  overlay.remove();
-
-  assert.ok(1 === 2);
+  assert.throws(() => {
+    overlay.remove(undefined);
+  }, Error, 'error is thrown with an invalid overlay');
 });


### PR DESCRIPTION
## Description
[Related Ticket](https://brightcove.atlassian.net/browse/WP-936)
Currently, overlays cannot be added/removed individually - this change introduces the ability to add/remove overlays individually (customer request)

## Specific Changes proposed
- New `add` function for adding overlays
- New `remove` function to remove individual overlays
- Updated docs to reflect the above changes


## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
