### PR TITLE
fix: package json export for publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
     "test/"
   ],
   "exports": {
+    ".": {
+      "require": "./dist/videojs-overlay.cjs.js",
+      "import": "./dist/videojs-overlay.es.js"
+    },
     "./plugin-only": {
       "require": "./dist/videojs-overlay.plugin.js",
       "import": "./dist/videojs-overlay.plugin.js"


### PR DESCRIPTION
## Description
When attempting to publish the package, `npm publish` was giving me the following error:

```
Error in dist/videojs-overlay.cjs.js:
node:internal/modules/cjs/loader:641
      throw e;
      ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /private/var/folders/5f/b4d6r7mn02x2cnhntjjxvjy80000gq/T/365a8c812afacffc52e90044e34cbe30afa627d0/node_modules/videojs-overlay/package.json
```

This change fixes the issue, and has been tested with dry-run

## Specific Changes proposed
- Add default exports to package.json

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
