### PR TITLE
Patch deprecated mergeOptions usage

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -131,8 +131,10 @@ class OverlayPlugin extends Plugin {
   }
 
   mapOverlays_(items) {
+    // Use merge function based on video.js version.
+    const merge = (videojs.obj && videojs.obj.merge) || videojs.mergeOptions;
     return items.map(o => {
-      const mergeOptions = videojs.mergeOptions(this.options, o);
+      const mergeOptions = merge(this.options, o);
       const attachToControlBar = typeof mergeOptions.attachToControlBar === 'string' || mergeOptions.attachToControlBar === true;
 
       if (!this.player.controls() || !this.player.controlBar) {


### PR DESCRIPTION
## Description
The following `videojs.mergeOptions` call used when adding or resetting overlay items: https://github.com/videojs/videojs-overlay/blob/f1fc4491982d964e476d0890cb44e2b915b1a97a/src/plugin.js#L135 results in this deprecation warning being triggered on VideoJS 8.x: 
`VIDEOJS: WARN: videojs.mergeOptions is deprecated and will be removed in 9.0; please use videojs.obj.merge instead`.

(For additional context on the deprecation, see https://videojs.org/guides/videojs-7-to-8/#newly-deprecated-functions.)

## Specific Changes proposed
This changeset patches the relevant callsite with the existing approach used within `reset`.

Existing approach: https://github.com/videojs/videojs-overlay/blob/f1fc4491982d964e476d0890cb44e2b915b1a97a/src/plugin.js#L98

Patch: https://github.com/videojs/videojs-overlay/commit/914d2c984249ab005f8282ab506f30ff490c0870

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
